### PR TITLE
Add shard entrypoint and remove MLP debug output

### DIFF
--- a/src/gradnite.cr
+++ b/src/gradnite.cr
@@ -1,0 +1,1 @@
+require "./gradnite/gradnite"

--- a/src/gradnite/gradnite.cr
+++ b/src/gradnite/gradnite.cr
@@ -167,7 +167,6 @@ module Gradnite
 
     def initialize(input_count : Int32, layer_sizes : Array(Int32))
       sz = [input_count] + layer_sizes
-      puts sz
       @layers = layer_sizes.map_with_index do |size, i|
         Layer.new(sz[i], sz[i + 1])
       end


### PR DESCRIPTION
## Summary
- add a shard root entrypoint (`src/gradnite.cr`) so consumers can `require "gradnite"` as documented
- remove a leftover debug `puts` from `MLP#initialize`

## Why
`README.md` currently instructs users to add the shard and then `require "gradnite"`, but the repository had no `src/gradnite.cr` file to satisfy that require path. Also, constructing an MLP emitted an unexpected stdout log from a debugging statement.

## Validation
- `crystal eval 'require "./src/gradnite"; n = Gradnite::Node.new(3.0); puts n.value'` → prints `3.0`
- `crystal eval 'require "./src/gradnite"; mlp = Gradnite::MLP.new(2, [3,1]); puts "ok"'` → prints `ok` (with no extra constructor debug output)
