### PR TITLE
fix: make draw_dot example compile again

### DIFF
--- a/example/binary_classifier.cr
+++ b/example/binary_classifier.cr
@@ -47,7 +47,7 @@ loss = Node.new(0.0)
   }
 end
 
-dot_str = draw_dot(loss)
+dot_str = draw_dot(loss, "tree.dot")
 
 puts ypred.map { |y| y.is_a?(Node) ? y.value : y[0].value }
 

--- a/src/gradnite/draw.cr
+++ b/src/gradnite/draw.cr
@@ -39,9 +39,8 @@ module Gradnite
 
     dot += "}\n"
 
+    # Write the output to the provided file and return the DOT string.
+    File.write(filePath, dot)
     dot
-
-    # Write the output to 'tree.dot'
-    File.write(filePath, dot_str)
   end
 end


### PR DESCRIPTION
## Summary
- Fix `Gradnite#draw_dot` to write the generated DOT text using the correct local variable.
- Keep the method return value as the DOT string after writing to disk.
- Update `example/binary_classifier.cr` to pass an output file path to `draw_dot`.

## Why
The binary classifier example no longer compiles because `draw_dot` now expects two arguments. The draw helper also referenced `dot_str`, which is undefined in the method body.

## Testing
- `crystal build example/binary_classifier.cr -o /tmp/gradnite-binary-classifier`

Build succeeded locally.
